### PR TITLE
adds address field to demo usage of create_dice function

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ def main():
 
     if inp.isdigit():
         # Single die
-        go_dice = create_dice(dice_devices[int(inp)])
+        go_dice = create_dice(dice_devices[int(inp)].address)
         connected_dice.append(go_dice)
     else:
         # Connect to all available dice


### PR DESCRIPTION
Usage of the `create_dice` function in the demo application, `main.py`, used the entire bleak device object as parameter, instead of the device's address field. 

This PR fixes this issue and allows the demo to continue without the crashing issue that was reported [here](https://github.com/ParticulaCode/GoDicePythonAPI/issues/2).
